### PR TITLE
Fix compile instruction and process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Do you have a mod you want to see included here? We are happy to take new contri
 3. Create the environment variable *SolastaInstallDir* and point it to your Solasta game home folder
     - tip: search for "edit the system environment variables" on windows search bar
 4. Open the project and clean the solution. This is key to allow the publicize assembly to be created
-5. Use "Install Release" or "Install Debug" to have the Mod installed directly to your Game Mods folder
+5. Build project on "Release Workflow" to create translation data
+6. Use "Release Install" or "Debug Install" to have the Mod installed directly to your Game Mods folder
 
 NOTE Unity Mod Manager and this mod template make use of [Harmony](https://go.microsoft.com/fwlink/?linkid=874338)
 

--- a/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
+++ b/SolastaUnfinishedBusiness/SolastaUnfinishedBusiness.csproj
@@ -26,6 +26,7 @@
       <PubliciseInputAssemblies Include="$(SolastaInstallDir)/Solasta_Data/Managed/Assembly-CSharp.dll" />
     </ItemGroup>
     <Publicise AssemblyPath="@(PubliciseInputAssemblies)" OutputPath="$(SolutionDir)lib/" />
+    <Copy SourceFiles="$(SolutionDir)lib/Assembly-CSharp_public.dll" DestinationFiles="$(ProjectDir)/Assembly-CSharp.dll" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
A clean project couldn't compile by following current instructions.
This PR updates both MSBuild and instructions to correct the problems.

* Copy publicized dll on Clean.
* Add instruction to build translation.zip (default is debug which does not build).
* Update old build target names in instruction.