### PR TITLE
Managed "Missing Spell Components" label in spell tooltip.

### DIFF
--- a/SolastaUnfinishedBusiness/Api/Helpers/LevelUpHelper.cs
+++ b/SolastaUnfinishedBusiness/Api/Helpers/LevelUpHelper.cs
@@ -18,8 +18,8 @@ namespace SolastaUnfinishedBusiness.Api.Helpers;
 
 internal static class LevelUpHelper
 {
-    internal const string ExtraClassTag = ""; //""@Class";
-    internal const string ExtraSubclassTag = ""; //""@Subclass";
+    internal const string ExtraClassTag = "@Class";
+    internal const string ExtraSubclassTag = "@Subclass";
 
     // keeps a tab on all heroes leveling up
     private static readonly Dictionary<RulesetCharacterHero, LevelUpData> LevelUpTab = new();

--- a/SolastaUnfinishedBusiness/Patches/SlotStatusTablePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/SlotStatusTablePatcher.cs
@@ -52,7 +52,9 @@ public static class SlotStatusTablePatcher
             int spellLevel)
         {
             var character = spellRepertoire?.GetCaster();
-
+            if (spellLevel == 0) // Missing cantrip localization
+                __instance.cantripLabel.Text = Gui.LocalizeSpellLevel(spellLevel);
+            
             // spellRepertoire is null during level up...
             if (spellLevel == 0 || character == null)
             {

--- a/SolastaUnfinishedBusiness/Patches/TooltipFeatureMissingComponentPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/TooltipFeatureMissingComponentPatcher.cs
@@ -1,0 +1,22 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+
+public class TooltipFeatureMissingComponentPatcher
+{
+    [HarmonyPatch(typeof(TooltipFeatureMissingComponent), nameof(TooltipFeatureMissingComponent.Bind))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class Bind_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(ref TooltipFeatureMissingComponent __instance)
+        {
+            __instance.gameObject.GetComponentInChildren<GuiLabel>().Text = "Tooltip/&InvalidComponentRequirementTitle";
+        }
+    }
+}


### PR DESCRIPTION
Hi,
in the spell tooltip there's a label which is not properly translated. I've modified it so that the proper translation is retrieved.
Before:
<img width="341" height="680" alt="image" src="https://github.com/user-attachments/assets/ac516b95-7b21-4e46-8990-76683830487c" />
After:
<img width="679" height="703" alt="image" src="https://github.com/user-attachments/assets/471ea360-abf0-453c-b9f1-dd5f3f4a6bc1" />
