### PR TITLE
Simpler crafting recipes

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
+++ b/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
@@ -341,6 +341,21 @@ internal static class CraftingAndItems
             Main.Settings.AddNewWeaponsAndRecipesToShops = toggle;
         }
 
+        if (Main.Settings.AddNewWeaponsAndRecipesToShops)
+        {
+            toggle = Main.Settings.NewWeaponsAndRecipesBaseInsteadOfPrimed;
+            if (UI.Toggle(Gui.Localize("ModUi/&NewWeaponsAndRecipesBaseInsteadOfPrimed"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.NewWeaponsAndRecipesBaseInsteadOfPrimed = toggle;
+            }
+
+            toggle = Main.Settings.NewWeaponsAndRecipesSimplified;
+            if (UI.Toggle(Gui.Localize("ModUi/&NewWeaponsAndRecipesSimplified"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.NewWeaponsAndRecipesSimplified = toggle;
+            }
+        }
+
         toggle = CraftingContext.RecipeBooks.Keys.Count == Main.Settings.CraftingInStore.Count;
         if (UI.Toggle(Gui.Localize("ModUi/&AddAllToStore"), ref toggle, UI.Width(125f)))
         {

--- a/SolastaUnfinishedBusiness/ItemCrafting/_ItemRecipeGenerationHelper.cs
+++ b/SolastaUnfinishedBusiness/ItemCrafting/_ItemRecipeGenerationHelper.cs
@@ -11,6 +11,28 @@ namespace SolastaUnfinishedBusiness.ItemCrafting;
 
 internal static class ItemRecipeGenerationHelper
 {
+
+    internal static Dictionary<ItemDefinition, ItemDefinition> enchantedToIngredient = new Dictionary<ItemDefinition, ItemDefinition>
+    {
+        { Ingredient_Enchant_MithralStone, _300_GP_Opal },
+        { Ingredient_Enchant_Crystal_Of_Winter, _100_GP_Pearl },
+        { Ingredient_Enchant_Blood_Gem, _500_GP_Ruby },
+        { Ingredient_Enchant_Soul_Gem, _1000_GP_Diamond },
+        { Ingredient_Enchant_Slavestone, _100_GP_Emerald },
+        { Ingredient_Enchant_Cloud_Diamond, _1000_GP_Diamond },
+        { Ingredient_Enchant_Stardust, _100_GP_Pearl },
+        { Ingredient_Enchant_Doom_Gem, _50_GP_Sapphire },
+        { Ingredient_Enchant_Shard_Of_Fire, _500_GP_Ruby },
+        { Ingredient_Enchant_Shard_Of_Ice, _50_GP_Sapphire },
+        { Ingredient_Enchant_LifeStone, _1000_GP_Diamond },
+        { Ingredient_Enchant_Diamond_Of_Elai, _100_GP_Emerald },
+        { Ingredient_PrimordialLavaStones, _20_GP_Amethyst },
+        { Ingredient_Enchant_Blood_Of_Solasta, Ingredient_Acid },
+        { Ingredient_Enchant_Medusa_Coral, _300_GP_Opal },
+        { Ingredient_Enchant_PurpleAmber, _50_GP_Sapphire },
+        { Ingredient_Enchant_Heartstone, _300_GP_Opal },
+        { Ingredient_Enchant_SpiderQueen_Venom, Ingredient_BadlandsSpiderVenomGland }
+    };
     internal static void AddRecipesFromItemCollection(ItemCollection itemCollection, bool isArmor = false)
     {
         var baseToPrimed = new Dictionary<ItemDefinition, ItemDefinition>
@@ -73,6 +95,13 @@ internal static class ItemRecipeGenerationHelper
                     : ItemBuilder.BuildNewMagicWeapon(baseItem, presentation, itemData.Name, itemData.Item);
                 newItem.GuiPresentation.spriteReference = presentation.GuiPresentation.SpriteReference;
                 var primedItem = baseToPrimed.TryGetValue(baseItem, out var value) ? value : baseItem;
+                
+                if (Main.Settings.AddNewWeaponsAndRecipesToShops
+                     && (Main.Settings.NewWeaponsAndRecipesBaseInsteadOfPrimed || Main.Settings.NewWeaponsAndRecipesSimplified))
+                {
+                    primedItem = baseItem;
+                }
+
                 var ingredients = new List<ItemDefinition> { primedItem };
 
                 if (itemCollection.CustomSubFeatures != null)
@@ -80,9 +109,14 @@ internal static class ItemRecipeGenerationHelper
                     newItem.AddCustomSubFeatures([.. itemCollection.CustomSubFeatures]);
                 }
 
-                ingredients.AddRange(itemData.Recipe.Ingredients
-                    .Where(ingredient => !ingredient.ItemDefinition.IsArmor && !ingredient.ItemDefinition.IsWeapon)
-                    .Select(x => x.ItemDefinition));
+                foreach (var ingredient in itemData.Recipe.Ingredients)
+                {
+                    if (!ingredient.ItemDefinition.IsArmor && !ingredient.ItemDefinition.IsWeapon)
+                    {
+                        if (Main.Settings.NewWeaponsAndRecipesSimplified && enchantedToIngredient.ContainsKey(ingredient.ItemDefinition)) ingredients.Add(enchantedToIngredient[ingredient.ItemDefinition]);
+                        else ingredients.Add(ingredient.ItemDefinition);
+                    }
+                }
 
                 var craftingManual = RecipeHelper.BuildRecipeManual(newItem, itemData.Recipe.CraftingHours,
                     itemData.Recipe.CraftingDC, [.. ingredients]);
@@ -107,28 +141,6 @@ internal static class ItemRecipeGenerationHelper
 
     internal static void AddIngredientEnchanting()
     {
-        var enchantedToIngredient = new Dictionary<ItemDefinition, ItemDefinition>
-        {
-            { Ingredient_Enchant_MithralStone, _300_GP_Opal },
-            { Ingredient_Enchant_Crystal_Of_Winter, _100_GP_Pearl },
-            { Ingredient_Enchant_Blood_Gem, _500_GP_Ruby },
-            { Ingredient_Enchant_Soul_Gem, _1000_GP_Diamond },
-            { Ingredient_Enchant_Slavestone, _100_GP_Emerald },
-            { Ingredient_Enchant_Cloud_Diamond, _1000_GP_Diamond },
-            { Ingredient_Enchant_Stardust, _100_GP_Pearl },
-            { Ingredient_Enchant_Doom_Gem, _50_GP_Sapphire },
-            { Ingredient_Enchant_Shard_Of_Fire, _500_GP_Ruby },
-            { Ingredient_Enchant_Shard_Of_Ice, _50_GP_Sapphire },
-            { Ingredient_Enchant_LifeStone, _1000_GP_Diamond },
-            { Ingredient_Enchant_Diamond_Of_Elai, _100_GP_Emerald },
-            { Ingredient_PrimordialLavaStones, _20_GP_Amethyst },
-            { Ingredient_Enchant_Blood_Of_Solasta, Ingredient_Acid },
-            { Ingredient_Enchant_Medusa_Coral, _300_GP_Opal },
-            { Ingredient_Enchant_PurpleAmber, _50_GP_Sapphire },
-            { Ingredient_Enchant_Heartstone, _300_GP_Opal },
-            { Ingredient_Enchant_SpiderQueen_Venom, Ingredient_BadlandsSpiderVenomGland }
-        };
-
         var recipes = enchantedToIngredient.Keys
             .Select(
                 item => RecipeDefinitionBuilder

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -295,6 +295,8 @@ public class Settings : UnityModManager.ModSettings
     public int RecipeCost { get; set; } = 200;
     public int TotalCraftingTimeModifier { get; set; }
     public bool AddNewWeaponsAndRecipesToShops { get; set; }
+    public bool NewWeaponsAndRecipesBaseInsteadOfPrimed { get; set; }
+    public bool NewWeaponsAndRecipesSimplified { get; set; }
     public bool AddNewScrollsToShops { get; set; }
     public bool AddNewScrollsToTreasure { get; set; }
     public List<string> CraftingInStore { get; } = [];

--- a/SolastaUnfinishedBusiness/Settings/empty.xml
+++ b/SolastaUnfinishedBusiness/Settings/empty.xml
@@ -631,6 +631,8 @@
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>false</AddNewWeaponsAndRecipesToShops>
+    <NewWeaponsAndRecipesBaseInsteadOfPrimed>false</NewWeaponsAndRecipesBaseInsteadOfPrimed>
+    <NewWeaponsAndRecipesSimplified>false</NewWeaponsAndRecipesSimplified>
     <CraftingInStore/>
     <EnableLoggingInvalidReferencesInUserCampaigns>false</EnableLoggingInvalidReferencesInUserCampaigns>
     <EnableSortingDungeonMakerAssets>false</EnableSortingDungeonMakerAssets>

--- a/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
+++ b/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
@@ -626,6 +626,8 @@
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>false</AddNewWeaponsAndRecipesToShops>
+    <NewWeaponsAndRecipesBaseInsteadOfPrimed>false</NewWeaponsAndRecipesBaseInsteadOfPrimed>
+    <NewWeaponsAndRecipesSimplified>false</NewWeaponsAndRecipesSimplified>  
     <CraftingInStore/>
     <EnableLoggingInvalidReferencesInUserCampaigns>false</EnableLoggingInvalidReferencesInUserCampaigns>
     <EnableSortingDungeonMakerAssets>false</EnableSortingDungeonMakerAssets>

--- a/SolastaUnfinishedBusiness/Settings/zappastuff.xml
+++ b/SolastaUnfinishedBusiness/Settings/zappastuff.xml
@@ -633,7 +633,9 @@
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>true</AddNewWeaponsAndRecipesToShops>
-    <CraftingInStore>
+    <NewWeaponsAndRecipesBaseInsteadOfPrimed>false</NewWeaponsAndRecipesBaseInsteadOfPrimed>
+    <NewWeaponsAndRecipesSimplified>false</NewWeaponsAndRecipesSimplified>
+  <CraftingInStore>
         <string>PrimedItems</string>
         <string>EnchantingIngredients</string>
         <string>RelicForgeries</string>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -9,6 +9,8 @@ ModUi/&AddHumanoidFavoredEnemyToRanger=Enable <color=#D89555>Humanoid</color> pr
 ModUi/&AddNewScrollsToShops=Add scrolls for new spells to appropriate shops <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddNewScrollsToTreasure=Add scrolls for new spells to appropriate treasure packs <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddNewWeaponsAndRecipesToShops=Add new weapons and recipes to shops <i><color=#F0DAA0>[hand wraps, halberds, pikes, long maces, hand crossbows]</color></i> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
+ModUi/&NewWeaponsAndRecipesBaseInsteadOfPrimed=<i>+ Use base weapons and armor as ingredients instead of Primed versions</i> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
+ModUi/&NewWeaponsAndRecipesSimplified=<i>+ Use simple all-in-one recipes <color=#F0DAA0>[base ingredients only, does not affect custom items from campaigns]</color></i> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddPaladinSmiteToggle=Add a toggle to allow <color=#D89555>Divine Smite</color> to only trigger on critical hits <i><color=#F0DAA0>[minimizes reaction prompts, applies to smite spells if 2024 smite spells are enabled]</color></i>
 ModUi/&AddPickPocketableLoot=Add pickpocketable loot <i><color=#F0DAA0>[suggested if <color=#D89555>Pickpocket</color> feat is enabled]</color></i>
 ModUi/&AddToStore=Add {0} 


### PR DESCRIPTION
This PR adds two new options in Crafting & Items > Crafting, under "Add new weapons and recipes to shops"

<img width="738" height="70" alt="3XUoaFp" src="https://github.com/user-attachments/assets/cd3540d3-107e-43c6-befa-c0ecf38ce228" />

- Use base weapons and armor as ingredients instead of Primed versions: self-explanatory.
- Use simple all-in-one recipes: this will remove intermediate crafted ingredients and replace them with the base ingredients required to craft them instead, this results in one single crafting recipe for each item using only base ingredients.

This does not however affect item recipes added as part of custom or official campaigns, which may require Primed or intermediate ingredients.

These options are compatible with existing save games and can be removed safely. Does not affect crafting already underway.