### PR TITLE
Fix incorrectly overwritten .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -308,6 +308,9 @@ __pycache__/
 # Linux direnv  files
 .envrc
 
+# Environment files with sensitive data
+Scripts/.env
+
 # Cake - Uncomment if you are using it
 # tools/**
 # !tools/packages.config


### PR DESCRIPTION
I noticed that a pull request incorrectly overwrote the .env file ignore added in .gitignore, which could lead to private data being accidentally uploaded.
Link: #72