### PR TITLE
Added option to learn all scroll crafting recipes.

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
+++ b/SolastaUnfinishedBusiness/Displays/CraftingAndItems.cs
@@ -318,6 +318,12 @@ internal static class CraftingAndItems
             }
         }
 
+        toggle = Main.Settings.LearnAllScrollRecipes;
+        if (UI.Toggle(Gui.Localize("ModUi/&LearnAllScrollRecipes"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.LearnAllScrollRecipes = toggle;
+        }
+
         UI.Label();
 
         var intValue = Main.Settings.RecipeCost;

--- a/SolastaUnfinishedBusiness/Patches/GameLocationManagerPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/GameLocationManagerPatcher.cs
@@ -101,6 +101,25 @@ public static class GameLocationManagerPatcher
                 gameLoreService.LearnRecipe(RecipeBasic_Bolts);
             }
 
+            if (Main.Settings.LearnAllScrollRecipes)
+            {
+                foreach (var item in DatabaseRepository.GetDatabase<ItemDefinition>())
+                {
+                    if (item != null)
+                    {
+                        var recipe = item.DocumentDescription?.RecipeDefinition;
+                        if (recipe && recipe.SpellDefinition)
+                        {
+                            if (!gameLoreService.KnownRecipes.Contains(recipe))
+                            {
+                                if (recipe.Name != "RecipeScroll_L8_AnimalShapes"
+                                    && recipe.Name != "RecipeScroll_L2_OfMirrorImage") gameLoreService.LearnRecipe(recipe);
+                            }
+                        }
+                    }
+                }
+            }
+
             //PATCH: remove carefully tracked dynamic item properties that have effect guid, but effect is removed
             //fixes Inventor's Infusions sometimes breaking and lingering forever without ability to remove them
             TrackItemsCarefully.FixDynamicPropertiesWithoutEffect();

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -293,6 +293,7 @@ public class Settings : UnityModManager.ModSettings
     public bool ShowCraftingRecipeInDetailedTooltips { get; set; }
     public bool ShowCraftedItemOnRecipeIcon { get; set; }
     public bool SwapCraftedItemAndRecipeIcons { get; set; }
+    public bool LearnAllScrollRecipes { get; set; }
     public int RecipeCost { get; set; } = 200;
     public int TotalCraftingTimeModifier { get; set; }
     public bool AddNewWeaponsAndRecipesToShops { get; set; }

--- a/SolastaUnfinishedBusiness/Settings/empty.xml
+++ b/SolastaUnfinishedBusiness/Settings/empty.xml
@@ -628,6 +628,7 @@
     <ShowCraftingRecipeInDetailedTooltips>false</ShowCraftingRecipeInDetailedTooltips>
     <ShowCraftedItemOnRecipeIcon>false</ShowCraftedItemOnRecipeIcon>
     <SwapCraftedItemAndRecipeIcons>false</SwapCraftedItemAndRecipeIcons>
+    <LearnAllScrollRecipes>false</LearnAllScrollRecipes>
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>false</AddNewWeaponsAndRecipesToShops>

--- a/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
+++ b/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
@@ -623,6 +623,7 @@
     <ShowCraftingRecipeInDetailedTooltips>true</ShowCraftingRecipeInDetailedTooltips>
     <ShowCraftedItemOnRecipeIcon>false</ShowCraftedItemOnRecipeIcon>
     <SwapCraftedItemAndRecipeIcons>false</SwapCraftedItemAndRecipeIcons>
+    <LearnAllScrollRecipes>false</LearnAllScrollRecipes>
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>false</AddNewWeaponsAndRecipesToShops>

--- a/SolastaUnfinishedBusiness/Settings/zappastuff.xml
+++ b/SolastaUnfinishedBusiness/Settings/zappastuff.xml
@@ -630,6 +630,7 @@
     <ShowCraftingRecipeInDetailedTooltips>true</ShowCraftingRecipeInDetailedTooltips>
     <ShowCraftedItemOnRecipeIcon>true</ShowCraftedItemOnRecipeIcon>
     <SwapCraftedItemAndRecipeIcons>true</SwapCraftedItemAndRecipeIcons>
+    <LearnAllScrollRecipes>false</LearnAllScrollRecipes>
     <RecipeCost>200</RecipeCost>
     <TotalCraftingTimeModifier>0</TotalCraftingTimeModifier>
     <AddNewWeaponsAndRecipesToShops>true</AddNewWeaponsAndRecipesToShops>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -403,6 +403,7 @@ ModUi/&Subclasses=<color=#F0DAA0>Subclasses</color>
 ModUi/&Subraces=<color=#F0DAA0>Subraces</color>
 ModUi/&SwapAbjurationSavant=Swap <b>Abjurer</b> <color=#D89555>Abjuration Savant</color> with 5e 2024 version <i><color=#F0DAA0>[learn 2 school spells when acquired, learn 1 more every time you gain a slot level]</color></i>
 ModUi/&SwapCraftedItemAndRecipeIcons=<i>+ Swap recipe and crafted item icons in shop</i>
+ModUi/&LearnAllScrollRecipes=Learn all base game scroll crafting recipes <i><color=#F0DAA0>[scroll kit proficiency and knowing the spell are still required to craft]</color></i>
 ModUi/&SwapEvocationPotentCantripAndSculptSpell=Swap <b>Evoker</b> <color=#D89555>Sculpt Spells</color> and <color=#D89555>Potent Cantrip</color> on progression
 ModUi/&SwapEvocationSavant=Swap <b>Evoker</b> <color=#D89555>Evocation Savant</color> with 5e 2024 version <i><color=#F0DAA0>[learn 2 school spells when acquired, learn 1 more every time you gain a slot level]</color></i>
 ModUi/&SwapMartialChampion=Swap <b>Martial Champion</b> with 5e 2024 version


### PR DESCRIPTION
Under Gameplay > Crafting & Items > Crafting, added an option that will have the current party learn all scroll crafting recipes. This occurs on save load or location transition. Known spells are checked before this happens to avoid needlessly adding the recipes over and over again.

As in the official rules, the scroll kit and knowing the spell are still required to craft the scroll.

Only works for base game spell scrolls, since UB spells do not have crafting recipes (yet). Animal Shapes and Mirror Image are excluded as they are bugged in the base game.


![2025-12-05 21_42_03-Solasta](https://github.com/user-attachments/assets/0a566296-cdf1-4531-bdb3-d7e97921f82a)
