### PR TITLE
Enemy spellcasters drop scribed spellbooks

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
@@ -85,6 +85,12 @@ internal static class CampaignsDisplay
             }
         }
 
+        toggle = Main.Settings.EnemySpellcastersDropScribedSpellbooks;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnemySpellcastersDropScribedSpellbooks"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.EnemySpellcastersDropScribedSpellbooks = toggle;
+        }
+
         UI.Label();
 
         toggle = Main.Settings.AltOnlyHighlightItemsInPartyFieldOfView;

--- a/SolastaUnfinishedBusiness/Models/SpellbookContext.cs
+++ b/SolastaUnfinishedBusiness/Models/SpellbookContext.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using SolastaUnfinishedBusiness.Api;
+using static SolastaUnfinishedBusiness.Api.DatabaseHelper;
+
+namespace SolastaUnfinishedBusiness.Models;
+internal static class SpellbookContext
+{
+    private static Dictionary<string, SpellDefinition> wizardSubspellParent = new Dictionary<string, SpellDefinition>();
+    private static Dictionary<string, List<SpellDefinition>> monsterSpellCache = new Dictionary<string, List<SpellDefinition>>();
+
+    private static ItemDefinition _spellbookDefinition = DatabaseHelper.GetDefinition<ItemDefinition>("Spellbook");
+
+    private static void initializeWizardSubspellParents()
+    {
+        if (wizardSubspellParent.Count == 0)
+        {
+            foreach (var duplet in SpellListDefinitions.SpellListWizard.SpellsByLevel)
+            {
+                var spells = duplet.spells;
+                foreach (var spell in spells)
+                {
+                    if (!wizardSubspellParent.ContainsKey(spell.Name))
+                    {
+                        wizardSubspellParent[spell.Name] = spell;
+                        foreach (var subspell in spell.SubspellsList)
+                        {
+                            wizardSubspellParent[subspell.Name] = spell;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    internal static SpellDefinition GetSpellRoot(SpellDefinition spell)
+    {
+        initializeWizardSubspellParents();
+
+        if (wizardSubspellParent.ContainsKey(spell.Name)) return wizardSubspellParent[spell.Name];
+        else return spell;
+    }
+
+    internal static List<SpellDefinition> GetWizardSpells(MonsterDefinition monsterDef)
+    {
+        var result = new List<SpellDefinition>();
+
+        if (monsterDef == null || monsterDef.Name == null) return result;
+        if (monsterSpellCache.ContainsKey(monsterDef.Name)) return monsterSpellCache[monsterDef.Name];
+
+        if (monsterDef.features != null)
+        {
+            foreach (var feature in monsterDef.Features)
+            {
+                if (feature is FeatureDefinitionCastSpell featureCastSpell)
+                {
+                    if (featureCastSpell.SpellListDefinition != null)
+                    {
+                        foreach (var spellDuplet in featureCastSpell.SpellListDefinition.SpellsByLevel)
+                        {
+                            var level = spellDuplet.Level;
+                            foreach (var spell in spellDuplet.Spells)
+                            {
+                                if (level > 0)
+                                {
+                                    var s = GetSpellRoot(spell);
+                                    if (!result.Contains(s) && SpellListDefinitions.SpellListWizard.ContainsSpell(s)) result.Add(s);
+                                }
+
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        monsterSpellCache[monsterDef.Name] = result;
+
+        return result;
+    }
+
+    internal static RulesetItemSpellbook MakeBlankSpellbook()
+    {
+        IRulesetItemFactoryService service = ServiceRepository.GetService<IRulesetItemFactoryService>();
+        RulesetItem item = service.CreateStandardItem(_spellbookDefinition);
+        if (item is RulesetItemSpellbook result) return result;
+
+        return null;
+    }
+
+    internal static void AddSpellbookToDroppedLoot(RulesetCharacterMonster monster)
+    {
+        if (monster == null || monster.Name == null || monster.MonsterDefinition == null || monster.droppedItems == null) return;
+
+        var spellList = GetWizardSpells(monster.MonsterDefinition);
+        if (spellList.Count > 0)
+        {
+            foreach (var droppedItem in monster.droppedItems)
+            {
+                if (droppedItem is RulesetItemSpellbook droppedSpellbook)
+                {
+                    if (droppedSpellbook.ScribedSpells.Count > 0)
+                    {
+                        return;
+                    }
+                }
+            }
+
+            var spellbook = MakeBlankSpellbook();
+            if (spellbook != null)
+            {
+                spellbook.ScribedSpells = spellList;
+                spellbook.OwnerName = monster.Name;
+
+                monster.droppedItems.Add(spellbook);
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetCharacterMonsterPatcher.cs
@@ -222,4 +222,20 @@ public static class RulesetCharacterMonsterPatcher
             }
         }
     }
+
+    [HarmonyPatch(typeof(RulesetCharacterMonster), nameof(RulesetCharacterMonster.InitializeDroppedItemsIFN))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class InitializeDroppedItemsIFN_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(RulesetCharacterMonster __instance)
+        {
+            //PATCH: Add Scribed Spellbooks to Enemy Spellcasters
+            if (Main.Settings.EnemySpellcastersDropScribedSpellbooks)
+            {
+                SpellbookContext.AddSpellbookToDroppedLoot(__instance);
+            }
+        }
+    }
 }

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -180,6 +180,7 @@ public class Settings : UnityModManager.ModSettings
     public int OverridePartySize { get; set; } = ToolsContext.GamePartySize;
     public bool AllowAllPlayersOnNarrativeSequences { get; set; }
     public bool AddPickPocketableLoot { get; set; }
+    public bool EnemySpellcastersDropScribedSpellbooks { get; set; }
     public bool AltOnlyHighlightItemsInPartyFieldOfView { get; set; }
     [Tag(Type = TagType.QoL)] public bool EnableAdditionalIconsOnLevelMap { get; set; }
     public bool HideExitsAndTeleportersGizmosIfNotDiscovered { get; set; }

--- a/SolastaUnfinishedBusiness/Settings/empty.xml
+++ b/SolastaUnfinishedBusiness/Settings/empty.xml
@@ -293,6 +293,7 @@
     <OverridePartySize>4</OverridePartySize>
     <AllowAllPlayersOnNarrativeSequences>false</AllowAllPlayersOnNarrativeSequences>
     <AddPickPocketableLoot>false</AddPickPocketableLoot>
+    <EnemySpellcastersDropScribedSpellbooks>false</EnemySpellcastersDropScribedSpellbooks>
     <AltOnlyHighlightItemsInPartyFieldOfView>false</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>false</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>false</HideExitsAndTeleportersGizmosIfNotDiscovered>

--- a/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
+++ b/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
@@ -289,6 +289,7 @@
     <OverridePartySize>2</OverridePartySize>
     <AllowAllPlayersOnNarrativeSequences>true</AllowAllPlayersOnNarrativeSequences>
     <AddPickPocketableLoot>false</AddPickPocketableLoot>
+    <EnemySpellcastersDropScribedSpellbooks>false</EnemySpellcastersDropScribedSpellbooks>
     <AltOnlyHighlightItemsInPartyFieldOfView>false</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>false</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>false</HideExitsAndTeleportersGizmosIfNotDiscovered>

--- a/SolastaUnfinishedBusiness/Settings/zappastuff.xml
+++ b/SolastaUnfinishedBusiness/Settings/zappastuff.xml
@@ -295,6 +295,7 @@
     <OverridePartySize>2</OverridePartySize>
     <AllowAllPlayersOnNarrativeSequences>false</AllowAllPlayersOnNarrativeSequences>
     <AddPickPocketableLoot>true</AddPickPocketableLoot>
+    <EnemySpellcastersDropScribedSpellbooks>true</EnemySpellcastersDropScribedSpellbooks>
     <AltOnlyHighlightItemsInPartyFieldOfView>true</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>true</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>true</HideExitsAndTeleportersGizmosIfNotDiscovered>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -13,6 +13,7 @@ ModUi/&NewWeaponsAndRecipesBaseInsteadOfPrimed=<i>+ Use base weapons and armor a
 ModUi/&NewWeaponsAndRecipesSimplified=<i>+ Use simple all-in-one recipes <color=#F0DAA0>[base ingredients only, does not affect custom items from campaigns]</color></i> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AddPaladinSmiteToggle=Add a toggle to allow <color=#D89555>Divine Smite</color> to only trigger on critical hits <i><color=#F0DAA0>[minimizes reaction prompts, applies to smite spells if 2024 smite spells are enabled]</color></i>
 ModUi/&AddPickPocketableLoot=Add pickpocketable loot <i><color=#F0DAA0>[suggested if <color=#D89555>Pickpocket</color> feat is enabled]</color></i>
+ModUi/&EnemySpellcastersDropScribedSpellbooks=Enemy spellcasters drop scribed spellbooks <i><color=#F0DAA0>[contains their known spells from the wizard list]</color></i>
 ModUi/&AddToStore=Add {0} 
 ModUi/&Advanced=<color=#F0DAA0>Advanced:</color> <b><i><color=#C04040E0>[Requires Restart]</color></i></b>
 ModUi/&AdvancedHelp=• <b><color=#C04040E0>ATTENTION:</color></b> These settings will require the player to have this mod installed


### PR DESCRIPTION
A new option under Gameplay > Campaign

![2025-12-11 10_34_07-Solasta](https://github.com/user-attachments/assets/14d1f02a-008f-4fda-a022-f305eda85944)



This option will make all enemy spellcasters that have Wizard spells drop a scribed spellbook on death containing all Wizard spells they know.

This option only works on enemies that have not yet spawned.