### PR TITLE
Enable out-of-combat targeting sight lines

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
@@ -119,6 +119,12 @@ internal static class CampaignsDisplay
             Main.Settings.HideExitsAndTeleportersGizmosIfNotDiscovered = toggle;
         }
 
+        toggle = Main.Settings.EnableOutOfCombatTargetingSightLines;
+        if (UI.Toggle(Gui.Localize("ModUi/&EnableOutOfCombatTargetingSightLines"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.EnableOutOfCombatTargetingSightLines = toggle;
+        }
+
         UI.Label();
 
         toggle = Main.Settings.EnableLogDialoguesToConsole;

--- a/SolastaUnfinishedBusiness/Patches/LineOfSightHelperPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/LineOfSightHelperPatcher.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Models;
+using TA;
+using UnityEngine;
+
+namespace SolastaUnfinishedBusiness.Patches;
+public static class LineOfSightHelperPatcher
+{
+    [HarmonyPatch(typeof(LineOfSightHelper), nameof(LineOfSightHelper.ShouldDisplay))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class ShouldDisplay_Patch
+    {
+        [UsedImplicitly]
+        public static void Postfix(LineOfSightHelper __instance,
+                SectorId hoveredLocationSectorID,
+                int3 hoveredLocation,
+                bool hoveredGUI,
+                ref bool __result
+            )
+        {
+            //PATCH: Out of combat, when targeting, sight lines will appear towards visible enemies
+            if (Main.Settings.EnableOutOfCombatTargetingSightLines)
+            {
+                //PATCH: Don't mess with the normal usage of this function, which isn't supposed to work outside of combat
+                if (__instance.gameLocationBattleService == null || __instance.gameLocationBattleService.IsBattleInProgress) return;
+
+                __instance.currentMode = LineOfSightHelper.FeedbackMode.VisibleTargetsFromPosition;
+                __result = true;
+            }
+
+
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -183,6 +183,7 @@ public class Settings : UnityModManager.ModSettings
     public bool AltOnlyHighlightItemsInPartyFieldOfView { get; set; }
     [Tag(Type = TagType.QoL)] public bool EnableAdditionalIconsOnLevelMap { get; set; }
     public bool HideExitsAndTeleportersGizmosIfNotDiscovered { get; set; }
+    public bool EnableOutOfCombatTargetingSightLines { get; set; }
     public bool EnableLogDialoguesToConsole { get; set; }
     public bool EnableSpeech { get; set; }
     public bool EnableSpeechOnNpcs { get; set; }

--- a/SolastaUnfinishedBusiness/Settings/empty.xml
+++ b/SolastaUnfinishedBusiness/Settings/empty.xml
@@ -296,6 +296,7 @@
     <AltOnlyHighlightItemsInPartyFieldOfView>false</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>false</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>false</HideExitsAndTeleportersGizmosIfNotDiscovered>
+    <EnableOutOfCombatTargetingSightLines>false</EnableOutOfCombatTargetingSightLines>
     <EnableLogDialoguesToConsole>false</EnableLogDialoguesToConsole>
     <EnableSpeech>false</EnableSpeech>
     <EnableSpeechOnNpcs>false</EnableSpeechOnNpcs>

--- a/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
+++ b/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
@@ -292,6 +292,7 @@
     <AltOnlyHighlightItemsInPartyFieldOfView>false</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>false</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>false</HideExitsAndTeleportersGizmosIfNotDiscovered>
+    <EnableOutOfCombatTargetingSightLines>false</EnableOutOfCombatTargetingSightLines>
     <EnableLogDialoguesToConsole>false</EnableLogDialoguesToConsole>
     <EnableSpeech>false</EnableSpeech>
     <EnableSpeechOnNpcs>false</EnableSpeechOnNpcs>

--- a/SolastaUnfinishedBusiness/Settings/zappastuff.xml
+++ b/SolastaUnfinishedBusiness/Settings/zappastuff.xml
@@ -298,6 +298,7 @@
     <AltOnlyHighlightItemsInPartyFieldOfView>true</AltOnlyHighlightItemsInPartyFieldOfView>
     <EnableAdditionalIconsOnLevelMap>true</EnableAdditionalIconsOnLevelMap>
     <HideExitsAndTeleportersGizmosIfNotDiscovered>true</HideExitsAndTeleportersGizmosIfNotDiscovered>
+    <EnableOutOfCombatTargetingSightLines>true</EnableOutOfCombatTargetingSightLines>
     <EnableLogDialoguesToConsole>true</EnableLogDialoguesToConsole>
     <EnableSpeech>true</EnableSpeech>
     <EnableSpeechOnNpcs>true</EnableSpeechOnNpcs>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -299,6 +299,7 @@ ModUi/&General=<color=#F0DAA0>General:</color>
 ModUi/&GeneralMenu=General
 ModUi/&GridSelectedColor=Change the movement <b><color=$$$$$$>grid color</color></b>
 ModUi/&HideExitAndTeleporterGizmosIfNotDiscovered=Hide exits and teleporters visual effects if not discovered yet
+ModUi/&EnableOutOfCombatTargetingSightLines=Enable sight lines towards visible enemies when targeting out-of-combat
 ModUi/&HideMonsterHitPoints=Display Monsters' health in steps of 25% / 50% / 75% / 100% instead of exact hit points
 ModUi/&HideQuickenedActionWhenMetamagicOff=<i>+ Hide this action when metamagic toggle is off</i>
 ModUi/&HighContrastTargetingAoeColor=Change AoE creatures <b><color=$$$$$$>highlight select color</color></b>


### PR DESCRIPTION
Added an option in under Campaign. If enabled, when targeting out-of-combat, sight lines point towards visible enemies. Useful when setting up to surprise.

![2025-12-11 16_10_03-greenshot  _ 2025-12-11 16_07_34-Solasta jpg  502_513  - Honeyview 5 51](https://github.com/user-attachments/assets/f5d7c5cb-c099-4273-a68f-bdc1d8213d79)
