### PR TITLE
Fix Innate Sorcery interaction with blade cantrips

### DIFF
--- a/SolastaUnfinishedBusiness/Models/2024SorcererContext.cs
+++ b/SolastaUnfinishedBusiness/Models/2024SorcererContext.cs
@@ -335,8 +335,11 @@ public static partial class Tabletop2024Context
             string effectName,
             ref ActionModifier attackModifier)
         {
-            if (attackProximity is not
-                (BattleDefinitions.AttackProximity.MagicRange or BattleDefinitions.AttackProximity.MagicReach))
+            if (attackProximity is
+                    not (BattleDefinitions.AttackProximity.MagicRange
+                    or BattleDefinitions.AttackProximity.MagicReach) &&
+                (attackMode is null ||
+                 !attackMode.AttackTags.Contains(AttackAfterMagicEffect.AttackAfterMagicEffectTag)))
             {
                 return;
             }


### PR DESCRIPTION
Add a new check to allow blade cantrips to roll attack with adv when Innate Sorcery is active.