### PR TITLE
Setting to prioritize pact slots usage by default

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
@@ -1284,6 +1284,7 @@ internal static class ToolsDisplay
             Main.Settings.EnableMinInOutAttributes = true;
             Main.Settings.DisplayAllKnownSpellsDuringLevelUp = true;
             Main.Settings.DisplayPactSlotsOnSpellSelectionPanel = true;
+            Main.Settings.AlwaysSpendPactSlotsFirst = true;
         }
 
         if (Main.Settings.EnableMulticlass)
@@ -1324,8 +1325,17 @@ internal static class ToolsDisplay
                 Main.Settings.EnableMinInOutAttributes = toggle;
             }
 
-            UI.Label();
-            UI.Label(Gui.Localize("ModUi/&MulticlassKeyHelp"));
+            toggle = Main.Settings.AlwaysSpendPactSlotsFirst;
+            if (UI.Toggle(Gui.Localize("ModUi/&AlwaysSpendPactSlotsFirst"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.AlwaysSpendPactSlotsFirst = toggle;
+            }
+
+            if (!Main.Settings.AlwaysSpendPactSlotsFirst)
+            {
+                UI.Label();
+                UI.Label(Gui.Localize("ModUi/&MulticlassKeyHelp"));    
+            }
         }
 
         UI.Label();

--- a/SolastaUnfinishedBusiness/Displays/RulesDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/RulesDisplay.cs
@@ -35,6 +35,7 @@ internal static class RulesDisplay
             Main.Settings.EnableMinInOutAttributes = true;
             Main.Settings.DisplayAllKnownSpellsDuringLevelUp = true;
             Main.Settings.DisplayPactSlotsOnSpellSelectionPanel = true;
+            Main.Settings.AlwaysSpendPactSlotsFirst = true;
         }
 
         if (Main.Settings.EnableMulticlass)
@@ -75,8 +76,17 @@ internal static class RulesDisplay
                 Main.Settings.EnableMinInOutAttributes = toggle;
             }
 
-            UI.Label();
-            UI.Label(Gui.Localize("ModUi/&MulticlassKeyHelp"));
+            toggle = Main.Settings.AlwaysSpendPactSlotsFirst;
+            if (UI.Toggle(Gui.Localize("ModUi/&AlwaysSpendPactSlotsFirst"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.AlwaysSpendPactSlotsFirst = toggle;
+            }
+
+            if (!Main.Settings.AlwaysSpendPactSlotsFirst)
+            {
+                UI.Label();
+                UI.Label(Gui.Localize("ModUi/&MulticlassKeyHelp"));    
+            }
         }
 
         UI.Label();

--- a/SolastaUnfinishedBusiness/Patches/RulesetSpellRepertoirePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/RulesetSpellRepertoirePatcher.cs
@@ -189,7 +189,9 @@ public static class RulesetSpellRepertoirePatcher
             var pactUsedSlots = SharedSpellsContext.GetWarlockUsedSlots(hero);
 
             var warlockSpellLevel = SharedSpellsContext.GetWarlockSpellLevel(hero);
-            var canConsumePactSlot = pactMaxSlots - pactUsedSlots > 0 && slotLevel <= warlockSpellLevel;
+            var canConsumePactSlot = pactMaxSlots - pactUsedSlots > 0 &&
+                                     (!Main.Settings.AlwaysSpendPactSlotsFirst && slotLevel <= warlockSpellLevel ||
+                                        slotLevel == warlockSpellLevel);
 
             __instance.GetSlotsNumber(slotLevel, out var totalRemainingSlots, out var totalMaxSlots);
 
@@ -203,6 +205,7 @@ public static class RulesetSpellRepertoirePatcher
 
             // determine if a pact slot should be forced
             var forceConsumePactSlot = sharedUsedSlots == sharedMaxSlots ||
+                                       Main.Settings.AlwaysSpendPactSlotsFirst ||
                                        (__instance.SpellCastingClass !=
                                            DatabaseHelper.CharacterClassDefinitions.Warlock && wasShiftPressed) ||
                                        (__instance.SpellCastingClass ==

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -98,6 +98,7 @@ public class Settings : UnityModManager.ModSettings
     public bool DisplayAllKnownSpellsDuringLevelUp { get; set; }
     public bool DisplayPactSlotsOnSpellSelectionPanel { get; set; }
     public bool EnableMinInOutAttributes { get; set; }
+    public bool AlwaysSpendPactSlotsFirst { get; set; }
     [Tag(Type = TagType.QoL)] public bool EnableActionSwitching { get; set; }
     [Tag(Type = TagType.T2014)] public bool DontEndTurnAfterReady { get; set; }
     [Tag(Type = TagType.T2014)] public bool EnableProneAction { get; set; }

--- a/SolastaUnfinishedBusiness/Settings/empty.xml
+++ b/SolastaUnfinishedBusiness/Settings/empty.xml
@@ -230,6 +230,7 @@
     <DisplayAllKnownSpellsDuringLevelUp>false</DisplayAllKnownSpellsDuringLevelUp>
     <DisplayPactSlotsOnSpellSelectionPanel>false</DisplayPactSlotsOnSpellSelectionPanel>
     <EnableMinInOutAttributes>false</EnableMinInOutAttributes>
+    <AlwaysSpendPactSlotsFirst>false</AlwaysSpendPactSlotsFirst>
     <EnableActionSwitching>false</EnableActionSwitching>
     <DontEndTurnAfterReady>false</DontEndTurnAfterReady>
     <EnableProneAction>false</EnableProneAction>

--- a/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
+++ b/SolastaUnfinishedBusiness/Settings/hiddenHax.xml
@@ -233,6 +233,7 @@
     <DisplayAllKnownSpellsDuringLevelUp>false</DisplayAllKnownSpellsDuringLevelUp>
     <DisplayPactSlotsOnSpellSelectionPanel>false</DisplayPactSlotsOnSpellSelectionPanel>
     <EnableMinInOutAttributes>false</EnableMinInOutAttributes>
+    <AlwaysSpendPactSlotsFirst>false</AlwaysSpendPactSlotsFirst>
     <EnableActionSwitching>true</EnableActionSwitching>
     <DontEndTurnAfterReady>true</DontEndTurnAfterReady>
     <EnableProneAction>false</EnableProneAction>

--- a/SolastaUnfinishedBusiness/Settings/zappastuff.xml
+++ b/SolastaUnfinishedBusiness/Settings/zappastuff.xml
@@ -233,6 +233,7 @@
     <DisplayAllKnownSpellsDuringLevelUp>true</DisplayAllKnownSpellsDuringLevelUp>
     <DisplayPactSlotsOnSpellSelectionPanel>true</DisplayPactSlotsOnSpellSelectionPanel>
     <EnableMinInOutAttributes>false</EnableMinInOutAttributes>
+    <AlwaysSpendPactSlotsFirst>false</AlwaysSpendPactSlotsFirst>
     <EnableActionSwitching>true</EnableActionSwitching>
     <DontEndTurnAfterReady>true</DontEndTurnAfterReady>
     <EnableProneAction>true</EnableProneAction>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -33,6 +33,7 @@ ModUi/&AllowMoreRealStateOnRestPanel=Allow more real state on rest panel <i><col
 ModUi/&AllowStackedMaterialComponent=Allow stacked material component <i><color=#F0DAA0>[e.g. 2x500gp diamond is equivalent to 1000gp diamond]</color></i>
 ModUi/&AllowTargetingSelectionWhenCastingChainLightningSpell=Allow target selection when casting the <color=#D89555>Chain Lightning</color> spell
 ModUi/&AltOnlyHighlightItemsInPartyFieldOfView=<color=#1E81B0>ALT</color> key only highlights gadgets in party field of view <i><color=#F0DAA0>[custom dungeons only]</color></i>
+ModUi/&AlwaysSpendPactSlotsFirst=<i>+ Always spend <color=#D89555>Warlock</color> pact slots first if possible</i>
 ModUi/&ArcaneShieldstaffOptions=Allow <color=#D89555>Arcane Shieldstaff</color> to be attuned by any class
 ModUi/&Backgrounds=<color=#F0DAA0>Backgrounds</color>
 ModUi/&BackgroundsAndRaces=Backgrounds & Races


### PR DESCRIPTION
The main goal was to have a setting to consume pact slots on Flexible Casting conversion of slots to sorcery points, since I was experiencing random results (I never knew when I had to have Shift pressed, even if I repeated the same process, I got different slot type consumption). But this is also a QoL as it guarantees you'll use pact slots for that spell level if you still have it, not needing to remember to press shift if it's from a non-Warlock spell (or wrongly pressing shift on an Warlock spell)

I've noticed a few behaviors that might cause issues, but they were present before my changes as well. I've documented them on a [separate issue](https://github.com/EnderWiggin/SolastaUnfinishedBusiness/issues/123) together with a nice test file, and I believe fixing them will complement this change nicely. Unfortunately, I lack the technical knowledge on modding Solasta to fix them on my own.

Because of the second issue mentioned on the issue above (regarding non-Warlock spells consuming higher level slots without benefits when pressing shift), I took the liberty of making this setting only consume pact slots if the spell is actually being cast at the pact slot level, since the user will have no control via the shift key when using this setting. This way, using low level spells won't consume higher level pact slots unnecessarily (and the user can upcast manually if they so wish, except for non-upcastable spells, which is the last point mentioned in the issue)

- New setting:
  - <img src="https://github.com/user-attachments/assets/f198b8ec-6e5d-44a5-923f-681eaac1eb2f" width="75%" height="75%"/>

- Old behavior is still present if the player wishes:
  - <img src="https://github.com/user-attachments/assets/5ead32f8-261b-4544-9cab-25180251a557" width="75%" height="75%"/>
