### PR TITLE
Add Widescreen Battle UI option

### DIFF
--- a/SolastaUnfinishedBusiness/Api/Helpers/UiHelpers.cs
+++ b/SolastaUnfinishedBusiness/Api/Helpers/UiHelpers.cs
@@ -19,4 +19,18 @@ internal static class UiHelpers
         }
         return new Vector2Int(0, 0);
     }
+    internal static float GetAspectRatio()
+    {
+        Vector2Int resolution = GetScreenResolution();
+        return (float)resolution.x / resolution.y;
+    }
+
+    internal static Vector2 GetOverlayCanvasSize()
+    {
+        if (ServiceRepository.GetService<IGuiService>() is not GuiManager gui)
+        {
+            return new Vector2(1920, 1080); //Reference Resolution
+        }
+        return gui.overlayCanvas.GetComponent<RectTransform>().rect.size;
+    }
 }

--- a/SolastaUnfinishedBusiness/Api/Helpers/UiHelpers.cs
+++ b/SolastaUnfinishedBusiness/Api/Helpers/UiHelpers.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace SolastaUnfinishedBusiness.Api.Helpers;
+internal static class UiHelpers
+{
+    internal static Vector2Int GetScreenResolution()
+    {
+        string[] resolutionStrings = ServiceRepository.GetService<IGraphicsSettingsService>().Resolution.Split(GraphicsResourceManager.ResolutionSeparators, StringSplitOptions.RemoveEmptyEntries);
+        if (resolutionStrings.Length >= 2)
+        {
+            int width = int.Parse(resolutionStrings[0].Trim());
+            int height = int.Parse(resolutionStrings[1].Trim());
+            return new Vector2Int(width, height);
+        }
+        return new Vector2Int(0, 0);
+    }
+}

--- a/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/GeneralDisplay.cs
@@ -206,6 +206,12 @@ internal static class ToolsDisplay
             Main.Settings.DisableUnofficialTranslations = toggle;
         }
 
+        toggle = Main.Settings.WideScreenBattleUI;
+        if (UI.Toggle(Gui.Localize("ModUi/&WideScreenBattleUI"), ref toggle, UI.AutoWidth()))
+        {
+            Main.Settings.WideScreenBattleUI = toggle;
+        }
+
         if (!Gui.GameCampaign)
         {
             return;

--- a/SolastaUnfinishedBusiness/Patches/BattleInitiativeTablePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/BattleInitiativeTablePatcher.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api.Helpers;
+using UnityEngine;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+internal class BattleInitiativeTablePatcher
+{
+    [HarmonyPatch(typeof(BattleInitiativeTable), nameof(BattleInitiativeTable.OnBeginShow))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class OnBeginShow_Patch
+    {
+        [UsedImplicitly]
+        public static void Prefix([NotNull] BattleInitiativeTable __instance)
+        {
+            if (Main.Settings.WideScreenBattleUI)
+            {
+                int width = UiHelpers.GetScreenResolution().x;
+                if (width > 1600)
+                {
+                    __instance.RectTransform.SetSizeWithCurrentAnchors(UnityEngine.RectTransform.Axis.Horizontal, width - 700);
+                }
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Patches/BattleInitiativeTablePatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/BattleInitiativeTablePatcher.cs
@@ -20,10 +20,13 @@ internal class BattleInitiativeTablePatcher
         {
             if (Main.Settings.WideScreenBattleUI)
             {
-                int width = UiHelpers.GetScreenResolution().x;
-                if (width > 1600)
+                float aspectRatio = UiHelpers.GetAspectRatio();
+                if (aspectRatio > 1.778f)
                 {
-                    __instance.RectTransform.SetSizeWithCurrentAnchors(UnityEngine.RectTransform.Axis.Horizontal, width - 700);
+                    // The Overlay Canvas may use a higher internal resolution than the actual window size. 
+                    //Using it as a reference ensures this works even for unconventional small but wide window sizes.
+                    float expanded = UiHelpers.GetOverlayCanvasSize().x - 552;
+                    __instance.RectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, expanded);
                 }
             }
         }

--- a/SolastaUnfinishedBusiness/Patches/CharacterControlPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterControlPanelPatcher.cs
@@ -20,11 +20,13 @@ public static class CharacterControlPanelPatcher
         {
             if (Main.Settings.WideScreenBattleUI)
             {
-                int width = UiHelpers.GetScreenResolution().x;
-                if (width > 1600)
+                float aspectRatio = UiHelpers.GetAspectRatio();
+                if (aspectRatio > 1.778f)
                 {
-                    int expansion = width - 400;
-                    __instance.RectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, expansion);
+                    // The Overlay Canvas may use a higher internal resolution than the actual window size. 
+                    //Using it as a reference ensures this works even for unconventional small but wide window sizes.
+                    float expanded = UiHelpers.GetOverlayCanvasSize().x - 210;
+                    __instance.RectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, expanded);
                 }                
             }
         }

--- a/SolastaUnfinishedBusiness/Patches/CharacterControlPanelPatcher.cs
+++ b/SolastaUnfinishedBusiness/Patches/CharacterControlPanelPatcher.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using HarmonyLib;
+using JetBrains.Annotations;
+using SolastaUnfinishedBusiness.Api.Helpers;
+using UnityEngine;
+
+namespace SolastaUnfinishedBusiness.Patches;
+
+[UsedImplicitly]
+public static class CharacterControlPanelPatcher
+{
+    [HarmonyPatch(typeof(CharacterControlPanel), nameof(CharacterControlPanel.OnBeginShow))]
+    [SuppressMessage("Minor Code Smell", "S101:Types should be named in PascalCase", Justification = "Patch")]
+    [UsedImplicitly]
+    public static class OnBeginShow_Patch
+    {
+        [UsedImplicitly]
+        public static void Prefix([NotNull] CharacterControlPanel __instance)
+        {
+            if (Main.Settings.WideScreenBattleUI)
+            {
+                int width = UiHelpers.GetScreenResolution().x;
+                if (width > 1600)
+                {
+                    int expansion = width - 400;
+                    __instance.RectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, expansion);
+                }                
+            }
+        }
+    }
+}

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -85,7 +85,8 @@ public class Settings : UnityModManager.ModSettings
     public bool EnablePcgRandom { get; set; }
     public bool EnableCustomPortraits { get; set; } = true;
     public bool DisableMultilineSpellOffering { get; set; }
-    public bool DisableUnofficialTranslations { get; set; } = true;
+    public bool DisableUnofficialTranslations { get; set; } = true; 
+    public bool WideScreenBattleUI { get; set; } = true;
 
     //
     // Gameplay - Rules

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -493,3 +493,4 @@ ModUi/&LegendaryTweaksDetails=Here you can change weapon type of legendary weapo
 ModUi/&WeaponMasterySystemCustomizeToggle=Customize weapon mastery properties
 ModUi/&WeaponMasterySystemCustomizeResetAll=Reset All
 ModUi/&WeaponMasterySystemCustomizeResetAllWarning=Will reset all weapon mastery properties to default
+ModUi/&WideScreenBattleUI=Enable Wide Screen Battle UI <color=#D89555>(For resolutions with a width greater than 1600 pixels)</color>

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -493,4 +493,4 @@ ModUi/&LegendaryTweaksDetails=Here you can change weapon type of legendary weapo
 ModUi/&WeaponMasterySystemCustomizeToggle=Customize weapon mastery properties
 ModUi/&WeaponMasterySystemCustomizeResetAll=Reset All
 ModUi/&WeaponMasterySystemCustomizeResetAllWarning=Will reset all weapon mastery properties to default
-ModUi/&WideScreenBattleUI=Enable Wide Screen Battle UI <color=#D89555>(For resolutions with a width greater than 1600 pixels)</color>
+ModUi/&WideScreenBattleUI=Enable Wide Screen Battle UI <i><color=#F0DAA0>(For resolutions with an Aspect Ratio greater than 16:9)</color></i>

--- a/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
+++ b/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
@@ -492,4 +492,4 @@ ModUi/&WeaponMasterySystemCustomizeResetAll=Redefinir tudo
 ModUi/&WeaponMasterySystemCustomizeResetAllWarning=Redefinirá todas as propriedades do domínio das armas para o padrão
 ModUi/&WeaponMasterySystemCustomizeToggle=Personalize propriedades de domínio das armas
 ModUi/&WildSurgeDieRollThreshold=<color=white>Definir limite de dado de chance de <color=#D89555>Magia Selvagem do Feiticeiro</color>:</color>\n<i><color=#F0DAA0>[onda selvagem é acionada se a rolagem for menor ou igual ao limite]</color></i>
-ModUi/&WideScreenBattleUI=Ativar interface de batalha wide-screen <color=#D89555>(Para resoluções com largura superior a 1600 pixels)</color>
+ModUi/&WideScreenBattleUI=Ativar interface de batalha wide-screen <i><color=#F0DAA0>(Para resoluções com proporção superior à 16:9)</color></i>

--- a/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
+++ b/SolastaUnfinishedBusiness/Translations/pt-BR/Settings-pt-BR.txt
@@ -492,3 +492,4 @@ ModUi/&WeaponMasterySystemCustomizeResetAll=Redefinir tudo
 ModUi/&WeaponMasterySystemCustomizeResetAllWarning=Redefinirá todas as propriedades do domínio das armas para o padrão
 ModUi/&WeaponMasterySystemCustomizeToggle=Personalize propriedades de domínio das armas
 ModUi/&WildSurgeDieRollThreshold=<color=white>Definir limite de dado de chance de <color=#D89555>Magia Selvagem do Feiticeiro</color>:</color>\n<i><color=#F0DAA0>[onda selvagem é acionada se a rolagem for menor ou igual ao limite]</color></i>
+ModUi/&WideScreenBattleUI=Ativar interface de batalha wide-screen <color=#D89555>(Para resoluções com largura superior a 1600 pixels)</color>


### PR DESCRIPTION
This adds an optional setting that expands the UI to use more of the space in wider monitors. Specifically, it dynamically widens the space reserved by the Initiative Table at the top, and the Character Control Panel, at the bottom. It only works on resolutions with a width greater than 1600 pixels, being inactive if the resolution is smaller.

Initiative before:
<img width="2560" height="1080" alt="image_2026-02-17_13-12-16" src="https://github.com/user-attachments/assets/d5d0698c-53dc-47d8-a6ee-a7bff96784ba" />

Initiative after:
<img width="2560" height="1080" alt="image_2026-02-17_13-09-23" src="https://github.com/user-attachments/assets/7c8ff3bc-10e6-4549-98d9-4e558235cb4e" />

Character Control before:
<img width="2560" height="1080" alt="image_2026-02-17_13-08-20" src="https://github.com/user-attachments/assets/05710293-a8b0-45df-bc57-b46407a51e15" />

Character Control after:
<img width="2560" height="1080" alt="image_2026-02-17_10-16-27" src="https://github.com/user-attachments/assets/33a2cc31-feb3-4a0d-a0d2-22c42ad8beaa" />