### PR TITLE
Allow pickpocket allies

### DIFF
--- a/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
+++ b/SolastaUnfinishedBusiness/Displays/CampaignsDisplay.cs
@@ -85,6 +85,15 @@ internal static class CampaignsDisplay
             }
         }
 
+        if (Main.Settings.AddPickPocketableLoot)
+        {
+            toggle = Main.Settings.PickPocketNonHostiles;
+            if (UI.Toggle(Gui.Localize("ModUi/&PickPocketNonHostiles"), ref toggle, UI.AutoWidth()))
+            {
+                Main.Settings.PickPocketNonHostiles = toggle;
+            }
+        }
+
         toggle = Main.Settings.EnemySpellcastersDropScribedSpellbooks;
         if (UI.Toggle(Gui.Localize("ModUi/&EnemySpellcastersDropScribedSpellbooks"), ref toggle, UI.AutoWidth()))
         {

--- a/SolastaUnfinishedBusiness/Models/PickPocketContext.cs
+++ b/SolastaUnfinishedBusiness/Models/PickPocketContext.cs
@@ -156,46 +156,48 @@ internal static class PickPocketContext
         {
             switch (monster.CharacterFamily)
             {
-                case "Humanoid" when monster.DefaultFaction == "HostileMonsters" &&
+                case "Humanoid" when monster.DefaultFaction == "HostileMonsters" ||
+                                     Main.Settings.PickPocketNonHostiles &&
                                      !monster.StealableLootDefinition:
-                {
-                    if (monster.ChallengeRating < 1.0)
                     {
-                        monster.stealableLootDefinition = pickPocketableLootTrivial;
-                    }
+                        if (monster.ChallengeRating < 1.0)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootTrivial;
+                        }
 
-                    if (monster.ChallengeRating > 0.9 &&
-                        monster.ChallengeRating < 2.0)
-                    {
-                        monster.stealableLootDefinition = pickPocketableLootA;
-                    }
+                        if (monster.ChallengeRating > 0.9 &&
+                            monster.ChallengeRating < 2.0)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootA;
+                        }
 
-                    if (monster.ChallengeRating > 1.9 &&
-                        monster.ChallengeRating < 3.0)
-                    {
-                        monster.stealableLootDefinition = pickPocketableLootB;
-                    }
+                        if (monster.ChallengeRating > 1.9 &&
+                            monster.ChallengeRating < 3.0)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootB;
+                        }
 
-                    if (monster.ChallengeRating > 2.9 &&
-                        monster.ChallengeRating < 5.0)
-                    {
-                        monster.stealableLootDefinition = pickPocketableLootC;
-                    }
+                        if (monster.ChallengeRating > 2.9 &&
+                            monster.ChallengeRating < 5.0)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootC;
+                        }
 
-                    if (monster.ChallengeRating > 4.9 &&
-                        monster.ChallengeRating < 7.0)
-                    {
-                        monster.stealableLootDefinition = pickPocketableLootD;
-                    }
+                        if (monster.ChallengeRating > 4.9 &&
+                            monster.ChallengeRating < 7.0)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootD;
+                        }
 
-                    if (monster.ChallengeRating > 6.9)
-                    {
-                        monster.stealableLootDefinition = pickPocketableLootE;
-                    }
+                        if (monster.ChallengeRating > 6.9)
+                        {
+                            monster.stealableLootDefinition = pickPocketableLootE;
+                        }
 
-                    break;
-                }
-                case "Undead" when monster.DefaultFaction.Contains("HostileMonsters") &&
+                        break;
+                    }
+                case "Undead" when monster.DefaultFaction.Contains("HostileMonsters") ||
+                                   Main.Settings.PickPocketNonHostiles &&
                                    !monster.StealableLootDefinition && !monster.Name.Contains("Ghost") &&
                                    !monster.Name.Contains("Spectral") && !monster.Name.Contains("Servant"):
                     monster.stealableLootDefinition = pickPocketableLootUndead;

--- a/SolastaUnfinishedBusiness/Settings.cs
+++ b/SolastaUnfinishedBusiness/Settings.cs
@@ -183,6 +183,7 @@ public class Settings : UnityModManager.ModSettings
     public int OverridePartySize { get; set; } = ToolsContext.GamePartySize;
     public bool AllowAllPlayersOnNarrativeSequences { get; set; }
     public bool AddPickPocketableLoot { get; set; }
+    public bool PickPocketNonHostiles { get; set; }
     public bool EnemySpellcastersDropScribedSpellbooks { get; set; }
     public bool AltOnlyHighlightItemsInPartyFieldOfView { get; set; }
     [Tag(Type = TagType.QoL)] public bool EnableAdditionalIconsOnLevelMap { get; set; }

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -344,7 +344,7 @@ ModUi/&OutlineGridWidthSpeed=<color=white>Multiply the outline grid animation sp
 ModUi/&OverrideMinMaxLevel=Override the required min and max levels when starting new adventures
 ModUi/&OverridePartySize=<color=white>Override the party size</color>
 ModUi/&Patches=<color=#F0DAA0>Patches:</color>
-ModUi/&PickPocketNonHostiles=Allow pickpocketing non-hostile NPCs <i><color=#F0DAA0>[may affect reputation]</color></i>
+ModUi/&PickPocketNonHostiles=Also add pickpocketable loot to many non-hostile NPCs <i><color=#F0DAA0>[failure will affect reputation]</color></i>
 ModUi/&PortraitsOpenFolder=Open portraits folder
 ModUi/&PrimedItems=Primed Items
 ModUi/&QuickCastLightCantripOnWornItemsFirst=Enable quick cast <color=#D89555>Light Cantrip</color> to use head, neck or torso worn items first

--- a/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
+++ b/SolastaUnfinishedBusiness/Translations/en/Settings-en.txt
@@ -344,6 +344,7 @@ ModUi/&OutlineGridWidthSpeed=<color=white>Multiply the outline grid animation sp
 ModUi/&OverrideMinMaxLevel=Override the required min and max levels when starting new adventures
 ModUi/&OverridePartySize=<color=white>Override the party size</color>
 ModUi/&Patches=<color=#F0DAA0>Patches:</color>
+ModUi/&PickPocketNonHostiles=Allow pickpocketing non-hostile NPCs <i><color=#F0DAA0>[may affect reputation]</color></i>
 ModUi/&PortraitsOpenFolder=Open portraits folder
 ModUi/&PrimedItems=Primed Items
 ModUi/&QuickCastLightCantripOnWornItemsFirst=Enable quick cast <color=#D89555>Light Cantrip</color> to use head, neck or torso worn items first


### PR DESCRIPTION
Sub-option for adding pickpocket loot to also add it to many non-hostile NPCs.
(Failure may affect reputation in the default campaigns.)